### PR TITLE
Rename pixel size property to match bioio-base

### DIFF
--- a/bioio_lif/reader.py
+++ b/bioio_lif/reader.py
@@ -58,6 +58,7 @@ class Reader(reader.Reader):
     _mosaic_xarray_data: Optional["xr.DataArray"] = None
     _dims: Optional[dimensions.Dimensions] = None
     _metadata: Optional[Any] = None
+    _physical_pixel_sizes: Optional[types.PhysicalPixelSizes] = None
     _scenes: Optional[Tuple[str, ...]] = None
     _current_scene_index: int = 0
     # Do not provide default value because
@@ -115,7 +116,6 @@ class Reader(reader.Reader):
 
         # Delayed storage
         self._scene_short_info: Dict[str, Any] = {}
-        self._px_sizes: Optional[types.PhysicalPixelSizes] = None
 
         # Enforce valid image
         if not self._is_supported_image(self._fs, self._path):
@@ -507,7 +507,7 @@ class Reader(reader.Reader):
             )
 
             # Store pixel sizes
-            self._px_sizes = px_sizes
+            self._physical_pixel_sizes = px_sizes
 
             return xr.DataArray(
                 image_data,
@@ -567,7 +567,7 @@ class Reader(reader.Reader):
             )
 
             # Store pixel sizes
-            self._px_sizes = px_sizes
+            self._physical_pixel_sizes = px_sizes
 
             return xr.DataArray(
                 image_data,
@@ -755,15 +755,15 @@ class Reader(reader.Reader):
         We currently do not handle unit attachment to these values. Please see the file
         metadata for unit information.
         """
-        if self._px_sizes is None:
+        if self._physical_pixel_sizes is None:
             # We get pixel sizes as a part of array construct
             # so simply run array construct
             self.dask_data
 
-        if self._px_sizes is None:
+        if self._physical_pixel_sizes is None:
             raise ValueError("Pixel sizes weren't created as a part of image reading")
 
-        return self._px_sizes
+        return self._physical_pixel_sizes
 
     def get_mosaic_tile_position(
         self, mosaic_tile_index: int, **kwargs: int


### PR DESCRIPTION
<!--
  Thank you for submitting a pull request!

  ⚠️⚠️ Please do the following before submitting: ⚠️⚠️

  - Read the CONTRIBUTING.md guide and make sure you've followed all the steps given.
  - Ensure that the code is up-to-date with the `main` branch.
  - Provide or update documentation for any feature added by your pull request.
  - Provide relevant tests for your feature or bug fix.

  ❗️ Also: ❗️

  Please name your pull request {development-type}/{short-description}.
  For example: feature/read-tiff-files
-->

### Link to Relevant Issue

This pull request resolves #14 : The `physical_pixel_sizes` property was not being updated on scene changes.
Requires the change in https://github.com/bioio-devs/bioio-base/pull/27 for the property to actually reset

### Description of Changes

Rename existing `_px_sizes` property to match `_physical_pixel_sizes` from `bioio-base`. This will make it so that when the property is reset from the base class (i.e., when the scene changes), pixel sizes will be recalculated in the LIF reader. 

### Testing
Verified that the existing tests still pass. Have not added a new unit test yet, but am open to doing so if needed.

Tested manually by reproducing the issue, as follows: 
```
img_bio = BioImage(lif_path_str, reader=bioio_lif.Reader)

img_bio.set_scene(scene1_name)
print(f"scene 1: {img_bio.physical_pixel_sizes}")

img_bio.set_scene(scene2_name)
# pixel size previously would have remained the same, but now updates to the new pixel size
print(f"scene 2: {img_bio.physical_pixel_sizes}") 
```