### PR TITLE
admin/bump-base

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-  "bioio-base>=0.3.0",
+  "bioio-base>=2.0.0",
   "dask[array]>=2021.4.1",
   "fsspec>=2022.8.0",
   "numpy>=1.16",


### PR DESCRIPTION
### Description 

Update the version of `bioio-base` to 2.0.0 to accommodate changes to the standard_metadata typing. 