### PR TITLE
Feature/share ci lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
       id-token: write   # This is required for requesting the JWT
       contents: read    # This is required for actions/checkout
     uses: bioio-devs/bioio-base/.github/workflows/shared_test.yml@main
+    with:
+      test_checkout_lfs: true
 
   # Shared lint workflow from bioio-base
   lint:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,14 +38,10 @@ jobs:
       id-token: write   # This is required for requesting the JWT
       contents: read    # This is required for actions/checkout
     uses: bioio-devs/bioio-base/.github/workflows/shared_test.yml@main
-    with:
-      test_checkout_lfs: true
 
   # Shared lint workflow from bioio-base
   lint:
     uses: bioio-devs/bioio-base/.github/workflows/shared_lint.yml@main
-    with:
-      lint_python_version: "3.11"
 
   # Check package performance
   benchmark:


### PR DESCRIPTION
Upgrade lint version to be able to remove the parameter to shared CI

### Link to Relevant Issue

Related to https://github.com/bioio-devs/bioio-base/issues/55

### Description of Changes

remove parameter forcing python to 3.11 when linting
