### PR TITLE
Fix channel name matching when some channels lack details (#49)

### DIFF
--- a/bioio_lif/reader.py
+++ b/bioio_lif/reader.py
@@ -434,6 +434,8 @@ class Reader(reader.Reader):
         scene_channel_list = []
         for channel in channels:
             matched_detail = detail_by_lut.get(channel.attrib.get("LUTName", ""))
+            # A channel only has a composite name when a detail matched its LUT;
+            # otherwise fall back to the channel's own LUTName (issue #49).
             if matched_detail is not None:
                 name = "--".join(
                     matched_detail.attrib.get(key, "")

--- a/bioio_lif/reader.py
+++ b/bioio_lif/reader.py
@@ -424,21 +424,24 @@ class Reader(reader.Reader):
         img = img_sets[scene_index]
 
         # Construct channel list
-        scene_channel_list = []
         channels = img.findall(".//ChannelDescription")
         channel_details = img.findall(".//WideFieldChannelInfo")
-        for i, channel in enumerate(channels):
-            if len(channels) <= len(channel_details):
-                channel_detail = channel_details[i]
-                scene_channel_list.append(
-                    (
-                        f"{channel_detail.attrib['LUT']}"
-                        f"--{channel_detail.attrib['ContrastingMethodName']}"
-                        f"--{channel_detail.attrib['FluoCubeName']}"
-                    )
+
+        detail_by_lut: Dict[str, ET.Element] = {}
+        for detail in channel_details:
+            detail_by_lut.setdefault(detail.attrib.get("LUT", ""), detail)
+
+        scene_channel_list = []
+        for channel in channels:
+            matched_detail = detail_by_lut.get(channel.attrib.get("LUTName", ""))
+            if matched_detail is not None:
+                name = "--".join(
+                    matched_detail.attrib.get(key, "")
+                    for key in ("LUT", "ContrastingMethodName", "FluoCubeName")
                 )
             else:
-                scene_channel_list.append(f"{channel.attrib['LUTName']}")
+                name = channel.attrib.get("LUTName", "")
+            scene_channel_list.append(name)
 
         # Attach channel names to coords
         coords[dimensions.DimensionNames.Channel] = scene_channel_list

--- a/bioio_lif/tests/test_reader.py
+++ b/bioio_lif/tests/test_reader.py
@@ -289,3 +289,68 @@ def test_lif_reader_mosaic_tile_inspection(
 
     # Assert equal
     np.testing.assert_array_equal(tile_from_m_index, tile_from_position)
+
+
+@pytest.mark.parametrize(
+    "channel_xml, expected_channel_names",
+    [
+        # Every channel has a matching detail
+        (
+            """
+            <root><Image>
+            <ChannelDescription LUTName="Gray"/>
+            <ChannelDescription LUTName="Green"/>
+            <WideFieldChannelInfo LUT="Gray"
+                ContrastingMethodName="TL-BF" FluoCubeName="EMP_BF"/>
+            <WideFieldChannelInfo LUT="Green"
+                ContrastingMethodName="FLUO" FluoCubeName="GFP"/>
+            </Image></root>
+            """,
+            ["Gray--TL-BF--EMP_BF", "Green--FLUO--GFP"],
+        ),
+        # Fewer details than channels: unmatched channels fall back to their own
+        # LUTName instead of forcing every channel onto the fallback (issue #49)
+        (
+            """
+            <root><Image>
+            <ChannelDescription LUTName="Gray"/>
+            <ChannelDescription LUTName="Green"/>
+            <ChannelDescription LUTName="Red"/>
+            <ChannelDescription LUTName="Blue"/>
+            <WideFieldChannelInfo LUT="Gray"
+                ContrastingMethodName="TL-BF" FluoCubeName="EMP_BF"/>
+            <WideFieldChannelInfo LUT="Green"
+                ContrastingMethodName="FLUO" FluoCubeName="GFP"/>
+            <WideFieldChannelInfo LUT="Red"
+                ContrastingMethodName="FLUO" FluoCubeName="RFP"/>
+            </Image></root>
+            """,
+            ["Gray--TL-BF--EMP_BF", "Green--FLUO--GFP", "Red--FLUO--RFP", "Blue"],
+        ),
+        # No details at all: every channel uses its LUTName
+        (
+            """
+            <root><Image>
+            <ChannelDescription LUTName="Gray"/>
+            <ChannelDescription LUTName="Red"/>
+            </Image></root>
+            """,
+            ["Gray", "Red"],
+        ),
+    ],
+)
+def test_channel_name_matching(
+    channel_xml: str,
+    expected_channel_names: List[str],
+) -> None:
+    xml = ET.fromstring(channel_xml)
+    image_short_info = {
+        "scale": (1.0, 1.0, 1.0, 1.0),
+        "dims": type("Dims", (), {"x": 2, "y": 2, "z": 1, "t": 1})(),
+    }
+
+    coords, _ = Reader._get_coords_and_physical_px_sizes(
+        xml, image_short_info, scene_index=0
+    )
+
+    assert list(coords[dimensions.DimensionNames.Channel]) == expected_channel_names


### PR DESCRIPTION
Fixes #49.

## Problem

`_get_coords_and_physical_px_sizes` decided whether to use detailed channel names with a single all-or-nothing length check:

```python
if len(channels) <= len(channel_details):
```

When a `.lif` file had more `ChannelDescription` entries than `WideFieldChannelInfo` details (e.g. 4 channels but only 3 named), this condition failed for **every** channel, so all channels fell back to the bare `LUTName` and the valid names were dropped. This is a regression from the aicsimageio behavior the reporter relied on.

## Fix

Match each channel to its detail independently by joining `WideFieldChannelInfo.LUT` to `ChannelDescription.LUTName`:

- Details are indexed once into a `LUT -> detail` map for O(n+m) lookup (`setdefault` keeps the first detail when several share a LUT, preserving prior first-match behavior).
- Channels with a matching detail keep their full `LUT--ContrastingMethodName--FluoCubeName` name.
- Channels without a matching detail fall back to their own `LUTName` instead of forcing every channel onto the fallback.

The reporter suggested an equivalent per-channel `next(...)` lookup; this implementation is the same idea indexed once up front rather than re-scanning the details list per channel.

## Verification

Existing channel names are unchanged:
- `s_1_t_1_c_2_z_1.lif` -> `["Gray--TL-BF--EMP_BF", "Green--FLUO--GFP"]`
- `s_1_t_4_c_2_z_1.lif` -> `["Gray--TL-PH--EMP_BF", "Green--FLUO--GFP"]`
- `tiled.lif` (no details) -> `["Gray", "Red", "Green", "Cyan"]`

The reporter's case now yields `["Gray--TL-BF--EMP_BF", "Green--FLUO--GFP", "Red--FLUO--RFP", "Blue"]` instead of dropping every name.

Added `test_channel_name_matching`, a parametrized unit test over synthetic XML covering the full-match, partial-match (#49), and no-detail cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)